### PR TITLE
Make CosyVoice3 TTS optional

### DIFF
--- a/mini-app/models/tts/__init__.py
+++ b/mini-app/models/tts/__init__.py
@@ -1,2 +1,22 @@
-from . import gtts, xtts, cosyvoice3  # triggers @register_tts decorators
+"""TTS engines package.
+
+This module imports available TTS engine implementations so that any
+``@register_tts`` decorators run on import.  Some engines depend on optional
+third-party libraries; if those dependencies are missing we still want the
+package to be importable so that the available engines can be used.
+"""
+
+from . import gtts, xtts  # always available engines
+
+# Optional engines ---------------------------------------------------------
+# CosyVoice3 requires an external ``tts`` package.  It may not be installed in
+# all environments (e.g. lightweight inference setups), so we attempt the
+# import but silently ignore a ``ModuleNotFoundError``.  This mirrors the
+# behaviour of other optional dependencies and keeps ``models.tts`` importable
+# even when CosyVoice3 isn't available.
+try:  # pragma: no cover - best effort import of optional dependency
+    from . import cosyvoice3  # triggers @register_tts decorators
+except ModuleNotFoundError:
+    pass
+
 


### PR DESCRIPTION
## Summary
- avoid hard dependency on missing CosyVoice3 TTS adapter

## Testing
- `python mini-app/test_claude.py` (fails: ImportError: libcudnn.so.9 missing)


------
https://chatgpt.com/codex/tasks/task_b_68c689cbb670832b908e3c4342917dd9