### PR TITLE
Handle two-latent XTTS models

### DIFF
--- a/mini-app/models/tts/xtts.py
+++ b/mini-app/models/tts/xtts.py
@@ -167,13 +167,15 @@ class XTTSEngine(BaseTTSEngine):
 
     def _synth_with_latents(self, text: str, lang: str, lat: Dict[str, torch.Tensor]):
         mdl = self._tts.synthesizer.tts_model
-        wav = mdl.inference(
-            text=text,
-            language=lang,
-            gpt_cond_latent=lat["gpt"],
-            diffusion_conditioning=lat["diff"],
-            speaker_embedding=lat["spk"],
-        )
+        inf_kwargs = {
+            "text": text,
+            "language": lang,
+            "gpt_cond_latent": lat["gpt"],
+            "speaker_embedding": lat["spk"],
+        }
+        if "diff" in lat:
+            inf_kwargs["diffusion_conditioning"] = lat["diff"]
+        wav = mdl.inference(**inf_kwargs)
         if not isinstance(wav, torch.Tensor):
             wav = torch.tensor(wav)
         if wav.dim() == 1:


### PR DESCRIPTION
## Summary
- Handle XTTS models that output only GPT and speaker latents
- Allow fallback XTTS engines to synthesize when diffusion latent is absent
- Support inference when diffusion conditioning is optional

## Testing
- `python -m py_compile mini-app/mp4_diarize_pipeline.py mini-app/models/tts/xtts.py`
- `python - <<'PY'
import sys
sys.path.append('mini-app')
import mp4_diarize_pipeline as pipeline
import torch, numpy as np, soundfile as sf
class DummyModel:
    def __init__(self): self.calls=0
    def get_conditioning_latents(self,*a,**k):
        self.calls+=1
        if self.calls==1: raise ValueError('not enough values to unpack (expected 3, got 2)')
        return torch.zeros(1), torch.ones(1)
class DummyEngine:
    def __init__(self,m): self._tts=type('T',(),{'synthesizer':type('S',(),{'tts_model':m})()})()
    def synthesize(self,*a,**k):
        sf.write(k['output_path'],np.zeros(160),16000); return k['output_path']
pipeline._load_xtts_engine=lambda m,l: DummyEngine(DummyModel())
from pathlib import Path; out=Path('tmp_test2'); out.mkdir(exist_ok=True)
import numpy as np
rng=np.random.default_rng(0)
data=rng.normal(0,0.01,32000).astype('float32')
input_wav=out/'dummy.wav'; sf.write(input_wav,data,16000)
segments=[{'start':0.0,'end':2.0,'speaker':'spk1'}]
voices_dir, lat_map=pipeline.build_reference_voices(input_wav, segments, workdir=out)
print('lat_map',lat_map)
full_wav, seg_audio=pipeline.synthesize_dub_track_xtts(segments,None,voices_dir,lat_map,'en',out)
print('output exists?',full_wav.exists(), 'segments:', seg_audio)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68c68ed83d78832bb84b0ddf6a7a5eab